### PR TITLE
fix: affix component overlapping content below

### DIFF
--- a/src/components/Music/MusicAffix.vue
+++ b/src/components/Music/MusicAffix.vue
@@ -1,6 +1,7 @@
 <template>
   <div style="z-index: 1000;padding-left:30px">
-    <a-affix :offset-bottom="offset">
+
+    <a-affix :offset-bottom="offset" style="width: 40px">
 
       <a-popover
         v-model="visible"


### PR DESCRIPTION
Ant Design 官方文档里的 Affix 组件也存在这个问题，我这边解决方法就是直接把width固定死了（
close #157 